### PR TITLE
Add build action for Apple silicon

### DIFF
--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -1,0 +1,58 @@
+name: Build arm64
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.6'
+
+      - name: Cache RubyGems
+        uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gem-
+
+      - name: Cache CocoaPods
+        uses: actions/cache@v2
+        with:
+          path: Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+
+      - name: Bundle install
+        run: |
+          gem install bundler
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+
+      - name: Pod install
+        run: bundle exec pod install
+
+      - name: Build for Apple silicon
+        run: |
+          xcodebuild \
+            -workspace Clipy.xcworkspace \
+            -scheme Clipy \
+            -configuration Release \
+            -destination 'platform=macOS,arch=arm64' \
+            build | xcpretty
+
+      - name: Upload app
+        uses: actions/upload-artifact@v2
+        with:
+          name: Clipy-macos-arm64
+          path: build/Release/Clipy.app


### PR DESCRIPTION
## Summary
- add a new GitHub Actions workflow to compile Clipy for macOS ARM64

## Testing
- `bundle install` *(fails: 403 Forbidden)*
- `bundle exec fastlane test` *(fails: bundler not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402155808c8333a622f8cac906a065